### PR TITLE
Add automatic installation of ScaleIO IM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 # Created by Jonas Rosland, @virtualswede & Matt Cowger, @mcowger
+# Modified to work with ScaleIO IM by Magnus Nilsson, @swevm
 # Many thanks to this post by James Carr: http://blog.james-carr.org/2013/03/17/dynamic-vagrant-nodes/
 
 # vagrant box

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "forwarded_port", guest: 6611, host: 6611
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm1.sh"
-          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall}"
+          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -p #{password}"
         end
       end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ domain = 'scaleio.local'
 nodes = ['tb', 'mdm1', 'mdm2']
 
 # add your IPs here
-network = "192.168.50"
+network = "192.168.102"
 
 clusterip = "#{network}.10"
 tbip = "#{network}.11"
@@ -24,7 +24,10 @@ firstmdmip = "#{network}.12"
 secondmdmip = "#{network}.13"
 
 # version of installation package
-version = "1.31-258.2.el6"
+version = "1.31-1277.3"
+
+#OS Version of package
+os="el6"
 
 # installation folder
 siinstall = "/opt/scaleio/siinstall"
@@ -65,7 +68,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{tbip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/tb.sh"
-          s.args   = "-v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall}"
+          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall}"
         end
       end
 
@@ -74,7 +77,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "forwarded_port", guest: 6611, host: 6611
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm1.sh"
-          s.args   = "-v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall}"
+          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall}"
         end
       end
 
@@ -82,7 +85,7 @@ Vagrant.configure("2") do |config|
         node_config.vm.network "private_network", ip: "#{secondmdmip}"
         node_config.vm.provision "shell" do |s|
           s.path = "scripts/mdm2.sh"
-          s.args   = "-v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -t #{tbip} -p #{password}"
+          s.args   = "-o #{os} -v #{version} -n #{packagename} -d #{device} -f #{firstmdmip} -s #{secondmdmip} -i #{siinstall} -t #{tbip} -p #{password}"
         end
       end
     end

--- a/scripts/mdm1.sh
+++ b/scripts/mdm1.sh
@@ -56,12 +56,12 @@ yum install java-1.7.0-openjdk -y
 cd /vagrant
 rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.${OS}.x86_64.rpm
 rpm -Uv ${PACKAGENAME}-sds-${VERSION}.${OS}.x86_64.rpm
+export GATEWAY_ADMIN_PASSWORD=${PASSWORD}
 rpm -Uv ${PACKAGENAME}-gateway-${VERSION}.noarch.rpm
 MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.${OS}.x86_64.rpm
 scli --mdm --add_primary_mdm --primary_mdm_ip ${FIRSTMDMIP} --accept_license
 
 sed -i 's/mdm.ip.addresses=/mdm.ip.addresses='${FIRSTMDMIP}','${SECONDMDMIP}'/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
-sed -i 's/gateway-admin.password=/gateway-admin.password='${PASSWORD}'/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
 service scaleio-gateway restart
 
 if [[ -n $1 ]]; then

--- a/scripts/mdm1.sh
+++ b/scripts/mdm1.sh
@@ -32,6 +32,10 @@ do
     SECONDMDMIP="$2"
     shift
     ;;
+    -p|--password)
+    PASSWORD="$2"
+    shift
+    ;;
     *)
     # unknown option
     ;;
@@ -57,7 +61,7 @@ MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.${OS}.x
 scli --mdm --add_primary_mdm --primary_mdm_ip ${FIRSTMDMIP} --accept_license
 
 sed -i 's/mdm.ip.addresses=/mdm.ip.addresses='${FIRSTMDMIP}','${SECONDMDMIP}'/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
-sed -i 's/gateway-admin.password=/gateway-admin.password=Scaleio123/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
+sed -i 's/gateway-admin.password=/gateway-admin.password='${PASSWORD}'/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
 service scaleio-gateway restart
 
 if [[ -n $1 ]]; then

--- a/scripts/mdm1.sh
+++ b/scripts/mdm1.sh
@@ -4,6 +4,10 @@ do
   key="$1"
 
   case $key in
+    -o|--os)
+    OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -37,17 +41,24 @@ done
 echo DEVICE  = "${DEVICE}"
 echo INSTALL PATH     = "${INSTALLPATH}"
 echo VERSION    = "${VERSION}"
+echo OS    = "${OS}"
 echo PACKAGENAME    = "${PACKAGENAME}"
 echo FIRSTMDMIP    = "${FIRSTMDMIP}"
 echo SECONDMDMIP    = "${SECONDMDMIP}"
 #echo "Number files in SEARCH PATH with EXTENSION:" $(ls -1 "${SEARCHPATH}"/*."${EXTENSION}" | wc -l)
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
+yum install java-1.7.0-openjdk -y
 cd /vagrant
-rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.x86_64.rpm
-rpm -Uv ${PACKAGENAME}-sds-${VERSION}.x86_64.rpm
-MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.${OS}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-sds-${VERSION}.${OS}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-gateway-${VERSION}.noarch.rpm
+MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.${OS}.x86_64.rpm
 scli --mdm --add_primary_mdm --primary_mdm_ip ${FIRSTMDMIP} --accept_license
+
+sed -i 's/mdm.ip.addresses=/mdm.ip.addresses='${FIRSTMDMIP}','${SECONDMDMIP}'/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
+sed -i 's/gateway-admin.password=/gateway-admin.password=Scaleio123/' /opt/emc/scaleio/gateway/webapps/ROOT/WEB-INF/classes/gatewayUser.properties
+service scaleio-gateway restart
 
 if [[ -n $1 ]]; then
   echo "Last line of file specified as non-opt/last argument:"

--- a/scripts/mdm2.sh
+++ b/scripts/mdm2.sh
@@ -4,6 +4,10 @@ do
   key="$1"
 
   case $key in
+    -o|--os)
+    OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -46,6 +50,7 @@ done
 echo DEVICE  = "${DEVICE}"
 echo INSTALL PATH     = "${INSTALLPATH}"
 echo VERSION    = "${VERSION}"
+echo OS    = "${OS}"
 echo PACKAGENAME    = "${PACKAGENAME}"
 echo FIRSTMDMIP    = "${FIRSTMDMIP}"
 echo SECONDMDMIP    = "${SECONDMDMIP}"
@@ -55,9 +60,9 @@ echo PASSWORD    = "${PASSWORD}"
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
 cd /vagrant
-rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.x86_64.rpm
-rpm -Uv ${PACKAGENAME}-sds-${VERSION}.x86_64.rpm
-MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-mdm-${VERSION}.${OS}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-sds-${VERSION}.${OS}.x86_64.rpm
+MDM_IP=${FIRSTMDMIP},${SECONDMDIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.${OS}.x86_64.rpm
 
 scli --login --mdm_ip ${FIRSTMDMIP} --username admin --password admin
 scli --mdm_ip ${FIRSTMDMIP} --set_password --old_password admin --new_password ${PASSWORD}
@@ -80,3 +85,4 @@ if [[ -n $1 ]]; then
   echo "Last line of file specified as non-opt/last argument:"
   tail -1 $1
 fi
+

--- a/scripts/tb.sh
+++ b/scripts/tb.sh
@@ -4,6 +4,10 @@ do
   key="$1"
 
   case $key in
+    -o|--os)
+    OS="$2"
+    shift
+    ;;
     -d|--device)
     DEVICE="$2"
     shift
@@ -37,6 +41,7 @@ done
 echo DEVICE  = "${DEVICE}"
 echo INSTALL PATH     = "${INSTALLPATH}"
 echo VERSION    = "${VERSION}"
+echo OS    = "${OS}"
 echo PACKAGENAME    = "${PACKAGENAME}"
 echo FIRSTMDMIP    = "${FIRSTMDMIP}"
 echo SECONDMDMIP    = "${SECONDMDMIP}"
@@ -44,9 +49,9 @@ echo SECONDMDMIP    = "${SECONDMDMIP}"
 truncate -s 100GB ${DEVICE}
 yum install numactl libaio -y
 cd /vagrant
-rpm -Uv ${PACKAGENAME}-tb-${VERSION}.x86_64.rpm
-rpm -Uv ${PACKAGENAME}-sds-${VERSION}.x86_64.rpm
-MDM_IP=${FIRSTMDMIP},${SECONDMDMIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-tb-${VERSION}.${OS}.x86_64.rpm
+rpm -Uv ${PACKAGENAME}-sds-${VERSION}.${OS}.x86_64.rpm
+MDM_IP=${FIRSTMDMIP},${SECONDMDMIP} rpm -Uv ${PACKAGENAME}-sdc-${VERSION}.${OS}.x86_64.rpm
 
 
 if [[ -n $1 ]]; then


### PR DESCRIPTION
Add variable for OS version to Vagrantfile to make it easier to deploy IM since it do not follow the same naming scheme as the other RPMs.
Few modifications in deploy scripts to obey OS variable setting.

Am using openjdk for java.